### PR TITLE
Fix loop in edit_instance function

### DIFF
--- a/8. Docker with SQLAlchemy/source_code/src/example/database.py
+++ b/8. Docker with SQLAlchemy/source_code/src/example/database.py
@@ -19,7 +19,7 @@ def delete_instance(model, id):
 
 def edit_instance(model, id, **kwargs):
     instance = model.query.filter_by(id=id).all()[0]
-    for attr, new_value in kwargs:
+    for attr, new_value in kwargs.items():
         setattr(instance, attr, new_value)
     commit_changes()
 


### PR DESCRIPTION
There is a small mistake in edit_instance code (articles/8. Docker with SQLAlchemy/source_code/src/example/database.py). 
PATCH method produced the error:
File "/home/max/python/articles/8. Docker with SQLAlchemy/source_code/src/example/database.py", line 22, in edit_instance
    for attr, new_value in kwargs:
ValueError: too many values to unpack (expected 2)

I fixed it by adding ".items()":
    for attr, new_value in kwargs.items():

and now it works fine.
